### PR TITLE
Final fix of `figures` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILDDIR:=build
 
 # useful parameter from above 
 # assumes there is a tikz folder in figures to compile them
-TKIZDIR:=$(ROOT)/$(FIGDIR)/tikz
+TIKZDIR:=$(ROOT)/$(FIGDIR)/tikz
 # get the main tex and seve the name wihtout extension in FILENAME
 FILENAME:=$(shell grep -Elr 'documentclass' $(SRCDIR)/*.tex | cut -d':' -f1)
 FILENAME:=$(notdir $(FILENAME))
@@ -18,7 +18,7 @@ FILENAME:=$(basename $(FILENAME))
 $(info The main tex is $(FILENAME).tex)
 TEXFILENAME:=$(FILENAME).tex
 DEPEND_SRCS:= $(shell find $(SRCDIR) -name '*.tex')
-DEPEND_SRCS_FIG:= $(shell find $(TKIZDIR) -name '*.tex')
+DEPEND_SRCS_FIG:= $(shell find $(TIKZDIR) -name '*.tex')
 # export this variable to access the .cls in the header folder
 export TEXINPUTS=.:./header/:
 
@@ -86,6 +86,12 @@ define build_debug
 	$(call bibtex, $(2))
 endef
 
+define build_figure
+	$(call build, $1, $(basename $2))
+	cp $(ROOT)/$(BUILDDIR)/$(basename $(notdir $2)).pdf $(ROOT)/$(FIGDIR)
+	echo "End of build_figure"
+endef
+
 all: $(DEPEND_SRCS)
 	$(call prepare_build)
 	$(call build, $(ROOT)/$(SRCDIR), $(FILENAME))
@@ -98,7 +104,7 @@ $(FILENAME): $(DEPEND_SRCS)
 
 figures: $(DEPEND_SRCS_FIG)
 	$(call prepare_build)
-	$(foreach source, $(DEPEND_SRCS_FIG), $(call build, $(TIKZDIR), $(basename $(source))) ; cp $(ROOT)/$(BUILDDIR)/$(basename $(notdir $(source))).pdf $(ROOT)/$(FIGDIR))
+	$(foreach source, $(DEPEND_SRCS_FIG), $(call build_figure, $(TIKZDIR), $(source)))
 
 fast: $(DEPEND_SRCS)
 	$(call prepare_build)

--- a/make_document_launcher.sh
+++ b/make_document_launcher.sh
@@ -13,6 +13,9 @@ do
     list_files+=" "$(find src/ -name '*.bib')
     list_files+=" "$(find src/ -name '*.cls')
     list_files+=" "$(find src/ -name '*.sty')
+    list_files+=" "$(find src/ -name '*.png')
+    list_files+=" "$(find src/ -name '*.jpg')
+    list_files+=" "$(find src/ -name '*.pdf')
     if [[ -z "${list_files// }" ]]; then
 	# list empty
 #	echo "no files to notify, waiting 1s..."


### PR DESCRIPTION
Fix the `figures` target in the makefile.
If there was multiple tikz sources, the `make figures` command crashed after the first figure.
A function has been built to make the target cleaner.
Now it can build each tikz sources present in the `figures/tikz` directory.

+ the `echo` line at the end of `build_figure` avoid a weird extension of the `cp` line raising an error at copy step of the first file.
+ this pull request adds the images files (jpg, png or pdf) in the dependencies of the non-figures targets for launchers to recompile if an image is modified. 