### PR TITLE
Fix processing of filenames with spaces

### DIFF
--- a/make_document_launcher.sh
+++ b/make_document_launcher.sh
@@ -20,29 +20,35 @@ do
     echo "##############################################################################################################"
     echo "########################################### Start Compilation ################################################"
     echo "##############################################################################################################"
-    list_files=$(find src/ -name '*.tex')
-    list_files+=" "$(find src/ -name '*.bib')
-    list_files+=" "$(find src/ -name '*.cls')
-    list_files+=" "$(find src/ -name '*.sty')
-    list_files+=" "$(find src/ -name '*.png')
-    list_files+=" "$(find src/ -name '*.jpg')
-    list_files+=" "$(find src/ -name '*.jpeg')
-    list_files+=" "$(find src/ -name '*.pdf')
-    list_files+=" "$(find src/ -name '*.eps')
-    list_files+=" "$(find src/ -name '*.svg')
-    if [[ -z "${list_files// }" ]]; then
+    
+    list_files=()
+
+    # list of extensions to watch
+    extensions=("tex" "bib" "cls" "sty" "png" "jpg" "jpeg" "pdf" "eps" "svg")
+    
+    for ext in "${extensions[@]}"; do
+        while IFS= read -r -d '' file; do
+            list_files+=("$file")
+        done < <(find src/ -name "*.$ext" -print0)
+    done
+
+    if [[ ${#list_files[@]} -eq 0 ]]; then
         # list empty
-        # echo "no files to notify, waiting 1s..."
+        echo "no files to watch, waiting 1s..."
         sleep 1
     else
         # list not empty
-        echo "the files to watch are "$list_files
-        inotifywait -e modify $list_files
+        echo "the files to watch are: "
+        printf "%s\n" "${list_files[@]}"
+
+        inotifywait -e modify "${list_files[@]}"
+
         if [ $# -eq 0 ]; then
             make fast
         else
             make "$@"
         fi
+
         sleep 0.1
     fi
 done

--- a/make_figure_launcher.sh
+++ b/make_figure_launcher.sh
@@ -19,16 +19,21 @@ do
     list_folders=$(find . -name "tikz" -type d)
     list_files=()
     for folder in $list_folders; do
-        list_files+=$(find $folder -name '*.tex')
+        while IFS= read -r -d '' file; do
+            list_files+=("$file")
+        done < <(find src/ -name "*.tex" -print0)
     done
-    if [[ -z "${list_files// }" ]]; then
+    if [[ ${#list_files[@]} -eq 0 ]]; then
         # list empty
-        # echo "no files to notify, waiting 1s..."
+        echo "no files to watch, waiting 1s..."
         sleep 1
     else
         # list not empty
-        echo "the files to watch are "$list_files
-        inotifywait -e modify $list_files
+        echo "the files to watch are: "
+        printf "%s\n" "${list_files[@]}"
+
+        inotifywait -e modify "${list_files[@]}"
+
         make figures
         sleep 0.1
     fi


### PR DESCRIPTION
o/

Having a file/dir with a space in its name will break the watching scripts, repeating the compilation without new saves.
A quick fix in how to extract the list of filenames is enough to avoid the problem!
I also added an extension list in the document-maker, maybe it will help changing it easily.